### PR TITLE
Update AWS instructions for recommender and sentiment

### DIFF
--- a/hw/recommender.md
+++ b/hw/recommender.md
@@ -211,8 +211,8 @@ Then from that remote machine:
 
 ```bash
 source activate pytorch_p36
-sudo pip install --upgrade pip
-sudo pip install numpy Flask
+pip install --upgrade pip
+pip install numpy Flask
 conda install gunicorn # regular pip install won't work it seems
 ```
 

--- a/hw/sentiment.md
+++ b/hw/sentiment.md
@@ -157,8 +157,8 @@ Then install software we need:
 
 ```bash
 source activate pytorch_p36
-sudo pip install --upgrade pip
-sudo pip install flask tweepy vaderSentiment colour
+pip install --upgrade pip
+pip install flask tweepy vaderSentiment colour
 conda install gunicorn # regular pip install won't work it seems
 ```
 


### PR DESCRIPTION
Hi, Terence.

There is a tiny error in the instructions for setting up our AWS instances to launch servers for both the `recommender` and `sentiment` projects. The commands with `sudo pip` should be replaced with `pip`, because:

* `sudo pip` installs packages system-wide, not inside an active environment. In fact, on AWS you can't even access them outside of an environment, because we do not have admin privileges, only user privileges. 

Now, you might ask why this problem didn't come up earlier when we did the `recommender` project. Well, in that case we were only installing `numpy` and `Flask`, both of which were already installed in the `pytorch_p36` environment! In this case, `vaderSentiment` and `colour` are *not* installed in `pytorch_p36`, hence the issues this time around.

Using `pip` fixes the issue, since `pip` installs packages inside the current environment.

Hope this helps!
--matt

P.S. Here is a reproducible example. Running on `Deep Learning AMI (Ubuntu) Version 24.2 (ami-02c253ecf7eaba73e)`

From outside an environment

```
$ sudo pip install words2num     # words2num is a lightweight package with no dependencies
$ pip list | grep words2num
$                  # ta-da, nothing!
```

From within an active environment

```
(pytorch_p36) ubuntu@ip-172-31-12-30:~$ sudo pip install words2num
(pytorch_p36) ubuntu@ip-172-31-12-30:~$ pip list | grep words2num
(pytorch_p36) ubuntu@ip-172-31-12-30:~$ 
```

In fact, in both cases you should see the following warning:

```
WARNING: The directory '/home/ubuntu/.cache/pip' or its parent directory is not owned by the
current user and caching wheels has been disabled. check the permissions and owner of that
directory. If executing pip with sudo, you may want sudo's -H flag.
```